### PR TITLE
Add Typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 import React from 'react';
+import { TextProperties } from 'react-native';
 
 declare module 'react-native-fontawesome' {
   export const Icons: { [key: string]: string };
-  const Icon: React.ComponentClass<any>;
+  const Icon: React.ComponentClass<TextProperties>;
   export default Icon;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+
+declare module 'react-native-fontawesome' {
+  export const Icons: { [key: string]: string };
+  const Icon: React.ComponentClass<any>;
+  export default Icon;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
-import React from 'react';
-import { TextProperties } from 'react-native';
-
-declare module 'react-native-fontawesome' {
+declare module "react-native-fontawesome" {
+  import React from "react";
+  import { TextProperties } from "react-native";
   export const Icons: { [key: string]: string };
   const Icon: React.ComponentClass<TextProperties>;
   export default Icon;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "main": "Icon.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/rturk/react-native-fontawesome.git"


### PR DESCRIPTION
This PR adds Typescript types for `Icons` and `Icon`.

~~I used `React.ComponentClass<any>` , so that any props can be added to the font awesome component. Looking at the code it looks like the props are passed through to `<Text />`, so this type declaration does not limit that feature.~~

Closes #27
