### PR TITLE
Add platform specific handling of font files

### DIFF
--- a/Icon.js
+++ b/Icon.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Text, StyleSheet } from 'react-native';
+import { Platform, Text, StyleSheet } from 'react-native';
 
 import Icons from './FontAwesomeIcons';
 
@@ -23,9 +23,10 @@ class Icon extends Component {
   }
 }
 
+const fontFamily = Platform.OS === 'ios' ? 'FontAwesome' : 'fontawesome-webfont';
 const styles = StyleSheet.create({
   icon: {
-    fontFamily:       'FontAwesome',
+    fontFamily:       fontFamily,
     backgroundColor:  'transparent',
   },
 });


### PR DESCRIPTION
Makes webfonts work in iOS and Android besides having to use different names in 'CSS' style.